### PR TITLE
feat: 필터 상태 URL 동기화 구현 (native Next.js)

### DIFF
--- a/__tests__/hooks/useAgeFilter.test.ts
+++ b/__tests__/hooks/useAgeFilter.test.ts
@@ -1,64 +1,92 @@
 import { renderHook, act } from '@testing-library/react';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { useAgeFilter } from '../../src/lib/useAgeFilter';
 import type { AgeFilter } from '../../types/index';
 
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(),
+  useRouter: jest.fn(),
+}));
+
+const mockUseSearchParams = useSearchParams as jest.Mock;
+const mockUseRouter = useRouter as jest.Mock;
+
 describe('useAgeFilter', () => {
-  it('shouldReturnEmptySelectedAgesInitially', () => {
-    const { result } = renderHook(() => useAgeFilter());
+  let mockReplace: jest.Mock;
+  let currentParams: URLSearchParams;
 
+  beforeEach(() => {
+    currentParams = new URLSearchParams();
+    mockReplace = jest.fn((url: string) => {
+      currentParams = new URLSearchParams(url.replace('?', ''));
+      mockUseSearchParams.mockReturnValue(currentParams);
+    });
+    mockUseSearchParams.mockReturnValue(currentParams);
+    mockUseRouter.mockReturnValue({ replace: mockReplace });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('초기 상태에서 선택된 나이가 없다', () => {
+    const { result } = renderHook(() => useAgeFilter());
     expect(result.current.selectedAges).toEqual([]);
   });
 
-  it('shouldAddAgeWhenToggleCalled', () => {
+  it('toggleAge 호출 시 나이가 추가된다', () => {
     const { result } = renderHook(() => useAgeFilter());
 
     act(() => {
       result.current.toggleAge('1' as AgeFilter);
     });
 
-    expect(result.current.selectedAges).toEqual(['1']);
+    expect(mockReplace).toHaveBeenCalledWith('?ages=1');
   });
 
-  it('shouldRemoveAgeWhenSameAgeToggledTwice', () => {
+  it('같은 나이를 두 번 toggle하면 나이가 제거된다', () => {
+    currentParams = new URLSearchParams('ages=1');
+    mockUseSearchParams.mockReturnValue(currentParams);
+
     const { result } = renderHook(() => useAgeFilter());
 
     act(() => {
       result.current.toggleAge('1' as AgeFilter);
     });
-    act(() => {
-      result.current.toggleAge('1' as AgeFilter);
-    });
 
-    expect(result.current.selectedAges).toEqual([]);
+    expect(mockReplace).toHaveBeenCalledWith('?');
   });
 
-  it('shouldAccumulateMultipleSelectedAges', () => {
-    const { result } = renderHook(() => useAgeFilter());
+  it('여러 나이를 toggle하면 모두 누적된다', () => {
+    const { result, rerender } = renderHook(() => useAgeFilter());
 
     act(() => {
       result.current.toggleAge('1' as AgeFilter);
     });
+    rerender();
+
     act(() => {
       result.current.toggleAge('2' as AgeFilter);
     });
+    rerender();
+
     act(() => {
       result.current.toggleAge('3' as AgeFilter);
     });
 
-    expect(result.current.selectedAges).toEqual(['1', '2', '3']);
+    expect(mockReplace).toHaveBeenLastCalledWith('?ages=1%2C2%2C3');
   });
 
-  it('shouldClearAllSelectedAgesWhenClearCalled', () => {
+  it('clearAll 호출 시 선택된 모든 나이가 제거된다', () => {
+    currentParams = new URLSearchParams('ages=1,2');
+    mockUseSearchParams.mockReturnValue(currentParams);
+
     const { result } = renderHook(() => useAgeFilter());
 
-    act(() => {
-      result.current.toggleAge('1' as AgeFilter);
-      result.current.toggleAge('2' as AgeFilter);
-    });
     act(() => {
       result.current.clearAll();
     });
 
-    expect(result.current.selectedAges).toEqual([]);
+    expect(mockReplace).toHaveBeenCalledWith('?');
   });
 });

--- a/__tests__/hooks/useCafeSelection.test.ts
+++ b/__tests__/hooks/useCafeSelection.test.ts
@@ -1,59 +1,84 @@
 import { renderHook, act } from '@testing-library/react';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { useCafeSelection } from '../../src/lib/useCafeSelection';
 
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(),
+  useRouter: jest.fn(),
+}));
+
+const mockUseSearchParams = useSearchParams as jest.Mock;
+const mockUseRouter = useRouter as jest.Mock;
+
 describe('useCafeSelection', () => {
-  it('shouldReturnNullSelectedCafeInitially', () => {
-    const { result } = renderHook(() => useCafeSelection());
+  let mockReplace: jest.Mock;
+  let currentParams: URLSearchParams;
 
+  beforeEach(() => {
+    currentParams = new URLSearchParams();
+    mockReplace = jest.fn((url: string) => {
+      currentParams = new URLSearchParams(url.replace('?', ''));
+      mockUseSearchParams.mockReturnValue(currentParams);
+    });
+    mockUseSearchParams.mockReturnValue(currentParams);
+    mockUseRouter.mockReturnValue({ replace: mockReplace });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('초기 상태에서 선택된 카페가 없다', () => {
+    const { result } = renderHook(() => useCafeSelection());
     expect(result.current.selectedCafeId).toBeNull();
   });
 
-  it('shouldSelectCafeWhenSelectCalled', () => {
+  it('selectCafe 호출 시 cafeId가 URL에 추가된다', () => {
     const { result } = renderHook(() => useCafeSelection());
 
     act(() => {
       result.current.selectCafe('cafe-123');
     });
 
-    expect(result.current.selectedCafeId).toBe('cafe-123');
+    expect(mockReplace).toHaveBeenCalledWith('?cafeId=cafe-123');
   });
 
-  it('shouldDeselectCafeWhenSameCafeSelectedAgain', () => {
+  it('같은 카페를 다시 선택하면 cafeId가 URL에서 제거된다', () => {
+    currentParams = new URLSearchParams('cafeId=cafe-123');
+    mockUseSearchParams.mockReturnValue(currentParams);
+
     const { result } = renderHook(() => useCafeSelection());
 
     act(() => {
       result.current.selectCafe('cafe-123');
     });
-    act(() => {
-      result.current.selectCafe('cafe-123');
-    });
 
-    expect(result.current.selectedCafeId).toBeNull();
+    expect(mockReplace).toHaveBeenCalledWith('?');
   });
 
-  it('shouldSwitchSelectionToNewCafe', () => {
+  it('다른 카페를 선택하면 cafeId가 새 카페로 변경된다', () => {
+    currentParams = new URLSearchParams('cafeId=cafe-123');
+    mockUseSearchParams.mockReturnValue(currentParams);
+
     const { result } = renderHook(() => useCafeSelection());
 
-    act(() => {
-      result.current.selectCafe('cafe-123');
-    });
     act(() => {
       result.current.selectCafe('cafe-456');
     });
 
-    expect(result.current.selectedCafeId).toBe('cafe-456');
+    expect(mockReplace).toHaveBeenCalledWith('?cafeId=cafe-456');
   });
 
-  it('shouldClearSelectionWhenClearCalled', () => {
+  it('clearSelection 호출 시 cafeId가 URL에서 제거된다', () => {
+    currentParams = new URLSearchParams('cafeId=cafe-123');
+    mockUseSearchParams.mockReturnValue(currentParams);
+
     const { result } = renderHook(() => useCafeSelection());
 
-    act(() => {
-      result.current.selectCafe('cafe-123');
-    });
     act(() => {
       result.current.clearSelection();
     });
 
-    expect(result.current.selectedCafeId).toBeNull();
+    expect(mockReplace).toHaveBeenCalledWith('?');
   });
 });

--- a/components/KakaoMap.tsx
+++ b/components/KakaoMap.tsx
@@ -128,7 +128,7 @@ export default function KakaoMap({
       marker.setImage(buildMarkerImage(state));
       marker.setZIndex(getMarkerZIndex(cafeId, selectedKidsCafeId));
     });
-  }, [selectedKidsCafeId, kidsCafes]);
+  }, [mapReady, selectedKidsCafeId, kidsCafes]);
 
   useEffect(() => {
     if (!mapRef.current) return;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { useState, useMemo } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import AgeFilterChips from '../../components/AgeFilterChips';
 import CafeListSection from '../../components/CafeListSection';
 const LocationBanner = dynamic(() => import('../../components/LocationBanner'), { ssr: false });
 import { useGeolocation } from '../lib/useGeolocation';
 import { useCafes } from '../lib/useCafes';
-import { useAgeFilter } from '../lib/useAgeFilter';
+import { useAgeFilter, useAgeChange } from '../lib/useAgeFilter';
 import { useCafeSelection } from '../lib/useCafeSelection';
 import { buildCafeListItems } from '../lib/cafeListUtils';
 import type { UserLocation } from '../lib/cafeListUtils';
@@ -20,12 +21,26 @@ const WelcomeModal = dynamic(() => import('../../components/WelcomeModal'), { ss
 type ViewMode = 'list' | 'map';
 
 export default function Home() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
   const geolocation = useGeolocation();
   const cafesState = useCafes();
-  const { selectedAges, setAges } = useAgeFilter();
-  const { selectedCafeId, selectCafe, clearSelection } = useCafeSelection();
+  const { selectedAges } = useAgeFilter();
+  const handleAgeChange = useAgeChange();
+  const { selectedCafeId, selectCafe } = useCafeSelection();
   const [viewMode, setViewMode] = useState<ViewMode>('list');
-  const [selectedDistrict, setSelectedDistrict] = useState<string | null>(null);
+
+  const selectedDistrict = searchParams.get('district');
+
+  function setDistrict(value: string | null) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set('district', value);
+    } else {
+      params.delete('district');
+    }
+    router.replace('?' + params.toString());
+  }
 
   const userLocation = useMemo((): UserLocation | null => {
     if (geolocation.status === 'granted' && geolocation.position !== null) {
@@ -39,18 +54,21 @@ export default function Home() {
     [cafesState.cafes, selectedAges, userLocation, selectedDistrict]
   );
 
-  function handleAgeChange(ages: Parameters<typeof setAges>[0]) {
-    setAges(ages);
-    clearSelection();
-  }
+  const filteredCafesForMap = useMemo(
+    () =>
+      selectedDistrict
+        ? cafesState.cafes.filter((cafe) => cafe.address.includes(selectedDistrict))
+        : cafesState.cafes,
+    [cafesState.cafes, selectedDistrict]
+  );
 
   function handleRequestPermission() {
-    setSelectedDistrict(null);
+    setDistrict(null);
     geolocation.requestPermission();
   }
 
   function handleChangeDistrict() {
-    setSelectedDistrict(null);
+    setDistrict(null);
   }
 
   return (
@@ -67,7 +85,7 @@ export default function Home() {
         selectedDistrict={selectedDistrict}
         districts={cafesState.districts}
         onRequestPermission={handleRequestPermission}
-        onSelectDistrict={setSelectedDistrict}
+        onSelectDistrict={setDistrict}
         onChangeDistrict={handleChangeDistrict}
       />
 
@@ -110,7 +128,7 @@ export default function Home() {
           aria-label="지도"
         >
           <KakaoMap
-            kidsCafes={cafesState.cafes}
+            kidsCafes={filteredCafesForMap}
             selectedKidsCafeId={selectedCafeId ?? undefined}
             selectedAges={selectedAges}
             onMarkerClick={selectCafe}

--- a/src/lib/useAgeFilter.ts
+++ b/src/lib/useAgeFilter.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 import type { AgeFilter } from '../../types/index';
 import { toggleAgeFilter } from './ageFilterChips';
 
@@ -12,19 +13,62 @@ export type AgeFilterState = {
 };
 
 export function useAgeFilter(): AgeFilterState {
-  const [selectedAges, setSelectedAges] = useState<AgeFilter[]>([]);
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const ages = searchParams.get('ages');
 
-  const toggleAge = useCallback((age: AgeFilter) => {
-    setSelectedAges((prev) => toggleAgeFilter(age, prev));
-  }, []);
+  const selectedAges: AgeFilter[] = ages ? (ages.split(',') as AgeFilter[]) : [];
 
-  const setAges = useCallback((ages: AgeFilter[]) => {
-    setSelectedAges(ages);
-  }, []);
+  const updateUrl = useCallback(
+    (ages: AgeFilter[]) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (ages.length === 0) {
+        params.delete('ages');
+      } else {
+        params.set('ages', ages.join(','));
+      }
+      router.replace('?' + params.toString());
+    },
+    [searchParams, router]
+  );
+
+  const toggleAge = useCallback(
+    (age: AgeFilter) => {
+      const next = toggleAgeFilter(age, selectedAges);
+      updateUrl(next);
+    },
+    [selectedAges, updateUrl]
+  );
+
+  const setAges = useCallback(
+    (ages: AgeFilter[]) => {
+      updateUrl(ages);
+    },
+    [updateUrl]
+  );
 
   const clearAll = useCallback(() => {
-    setSelectedAges([]);
-  }, []);
+    updateUrl([]);
+  }, [updateUrl]);
 
   return { selectedAges, toggleAge, setAges, clearAll };
+}
+
+export function useAgeChange(): (ages: AgeFilter[]) => void {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  return useCallback(
+    (ages: AgeFilter[]) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (ages.length === 0) {
+        params.delete('ages');
+      } else {
+        params.set('ages', ages.join(','));
+      }
+      params.delete('cafeId');
+      router.replace('?' + params.toString());
+    },
+    [searchParams, router]
+  );
 }

--- a/src/lib/useCafeSelection.ts
+++ b/src/lib/useCafeSelection.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 
 export type CafeSelectionState = {
   selectedCafeId: string | null;
@@ -9,15 +10,29 @@ export type CafeSelectionState = {
 };
 
 export function useCafeSelection(): CafeSelectionState {
-  const [selectedCafeId, setSelectedCafeId] = useState<string | null>(null);
+  const searchParams = useSearchParams();
+  const router = useRouter();
 
-  const selectCafe = useCallback((id: string) => {
-    setSelectedCafeId((prev) => (prev === id ? null : id));
-  }, []);
+  const selectedCafeId = searchParams.get('cafeId');
+
+  const selectCafe = useCallback(
+    (id: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (params.get('cafeId') === id) {
+        params.delete('cafeId');
+      } else {
+        params.set('cafeId', id);
+      }
+      router.replace(`?${params.toString()}`);
+    },
+    [searchParams, router],
+  );
 
   const clearSelection = useCallback(() => {
-    setSelectedCafeId(null);
-  }, []);
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete('cafeId');
+    router.replace(`?${params.toString()}`);
+  }, [searchParams, router]);
 
   return { selectedCafeId, selectCafe, clearSelection };
 }


### PR DESCRIPTION
## Summary

- `useAgeFilter`, `useCafeSelection`: `useState` → `useSearchParams` + `useRouter`로 교체하여 필터 상태를 URL에 동기화
- `useAgeChange` 훅 추가: 나이 필터 변경 시 `ages` URL 업데이트 + `cafeId` 초기화를 단일 `router.replace`로 처리
- `page.tsx`: `selectedDistrict` URL 동기화, `filteredCafesForMap`으로 지도에도 자치구 필터 적용
- `KakaoMap`: `mapReady`를 Effect 의존성에 추가하여 URL `cafeId`로 직접 접속 시 초기 마커 중심 이동 처리
- 테스트: `next/navigation` mock으로 훅 테스트 업데이트

## URL 포맷

| 파라미터 | 예시 | 설명 |
|---------|------|------|
| `ages` | `?ages=3%2C5%2C7` | 나이 필터 (comma-separated) |
| `cafeId` | `?cafeId=KC240901` | 선택된 카페 |
| `district` | `?district=마포구` | 선택된 자치구 |

## 구현 결정 사항

- nuqs 라이브러리 대신 native `useSearchParams` + `useRouter` 사용 (외부 의존성 최소화)
- 여러 훅이 동시에 `router.replace`를 호출하는 경쟁 조건 방지를 위해 `useAgeChange`에서 단일 호출로 통합
- URL 인코딩 일관성: `params.set()`을 사용해 항상 `%2C` 인코딩으로 통일

## Test plan

- [x] 나이 필터 클릭 → URL에 `?ages=3%2C5` 반영 확인
- [x] 자치구 선택 → URL에 `?district=마포구` 반영 확인
- [x] 카페 클릭 → URL에 `?cafeId=xxx` 반영 확인
- [x] URL 복사 후 새 탭 → 필터 상태 복원 확인
- [x] URL `cafeId` 직접 접속 → 지도가 해당 마커 중심으로 이동 확인
- [x] URL `district` 직접 접속 → 지도에 해당 자치구 마커만 표시 확인

Closes #16