### PR TITLE
feat: 카페별 동적 OG 메타태그 구현

### DIFF
--- a/components/CafeListSection.tsx
+++ b/components/CafeListSection.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react';
 import KidsCafeCard from './KidsCafeCard';
 import type { CafeListItem } from '../src/lib/cafeListUtils';
 import { isOpenToday } from '../src/lib/openStatus';
+import { useShareMenu } from '../src/lib/useShareMenu';
 
 export interface CafeListSectionProps {
   items: CafeListItem[];
@@ -19,6 +20,7 @@ export default function CafeListSection({
   scrollKey,
 }: CafeListSectionProps) {
   const listRef = useRef<HTMLDivElement>(null);
+  const { openMenuId, toggleMenu, closeMenu, copiedId, copyLink, shareKakao } = useShareMenu();
 
   useEffect(() => {
     if (!selectedCafeId || !listRef.current) return;
@@ -37,16 +39,23 @@ export default function CafeListSection({
 
   return (
     <div ref={listRef} className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-      {items.map(({ cafe, matchStatus, distanceKm }, index) => (
+      {items.map(({ cafe, matchStatus, distanceKm }) => (
         <div key={cafe.id} data-cafe-id={cafe.id}>
           <KidsCafeCard
             kidsCafe={cafe}
             matchStatus={matchStatus}
             distanceKm={distanceKm ?? undefined}
             isOpen={isOpenToday(cafe.operatingHours)}
-            onClick={() => onCardClick(cafe.id)}
+            onClick={() => { closeMenu(); onCardClick(cafe.id); }}
             isSelected={selectedCafeId === cafe.id}
-            priority={index === 0}
+            onShareMenuToggle={() => toggleMenu(cafe.id)}
+            onShare={(action) =>
+              action === 'link'
+                ? copyLink(cafe.id)
+                : shareKakao(cafe.id, cafe)
+            }
+            isShareMenuOpen={openMenuId === cafe.id}
+            isCopied={copiedId === cafe.id}
           />
         </div>
       ))}

--- a/components/KidsCafeCard/index.tsx
+++ b/components/KidsCafeCard/index.tsx
@@ -18,7 +18,10 @@ export default function KidsCafeCard({
   isOpen,
   onClick,
   isSelected,
-  priority = false,
+  onShareMenuToggle,
+  onShare,
+  isShareMenuOpen,
+  isCopied,
 }: KidsCafeCardProps) {
   const opacityClass = getCardOpacity(matchStatus);
   const distance = formatDistance(distanceKm);
@@ -43,7 +46,6 @@ export default function KidsCafeCard({
             className="object-cover"
             sizes="(max-width: 640px) 100vw, 50vw"
             quality={60}
-            priority={priority}
           />
         ) : (
           <div
@@ -122,6 +124,43 @@ export default function KidsCafeCard({
             </a>
           )}
         </div>
+
+        {onShareMenuToggle && (
+          <div className="relative mt-1">
+            <button
+              className="w-full flex items-center justify-center gap-1 rounded-lg border border-gray-300 text-gray-700 text-sm font-semibold py-2 hover:bg-gray-50 transition-colors"
+              onClick={(e) => {
+                e.stopPropagation();
+                onShareMenuToggle();
+              }}
+            >
+              {isCopied ? '✅ 복사됨' : '🔗 공유하기 ▾'}
+            </button>
+
+            {isShareMenuOpen && (
+              <div className="absolute bottom-full left-0 mb-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden z-10">
+                <button
+                  className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onShare?.('link');
+                  }}
+                >
+                  🔗 링크 복사
+                </button>
+                <button
+                  className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2 border-t border-gray-100"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onShare?.('kakao');
+                  }}
+                >
+                  💬 카카오톡 공유
+                </button>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </article>
   );

--- a/components/KidsCafeCard/index.tsx
+++ b/components/KidsCafeCard/index.tsx
@@ -134,7 +134,16 @@ export default function KidsCafeCard({
                 }}
                 aria-label="공유하기"
               >
-                {isCopied ? '✅' : '🔗'}
+                {isCopied ? (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-green-500" aria-hidden="true">
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                ) : (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" />
+                    <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" /><line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+                  </svg>
+                )}
               </button>
 
               {isShareMenuOpen && (

--- a/components/KidsCafeCard/index.tsx
+++ b/components/KidsCafeCard/index.tsx
@@ -164,7 +164,10 @@ export default function KidsCafeCard({
                       onShare?.('kakao');
                     }}
                   >
-                    💬 카카오톡
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                      <path fill="#3A1D1D" d="M12 3C6.477 3 2 6.477 2 10.8c0 2.7 1.6 5.08 4.03 6.52l-1.02 3.8a.3.3 0 0 0 .46.32l4.4-2.9c.7.1 1.42.16 2.13.16 5.523 0 10-3.477 10-7.8S17.523 3 12 3z"/>
+                    </svg>
+                    카카오톡
                   </button>
                 </div>
               )}

--- a/components/KidsCafeCard/index.tsx
+++ b/components/KidsCafeCard/index.tsx
@@ -105,7 +105,7 @@ export default function KidsCafeCard({
           {kidsCafe.phone?.trim() && (
             <a
               href={`tel:${kidsCafe.phone.trim()}`}
-              className="flex-1 flex items-center justify-center gap-1 rounded-lg border border-gray-300 text-gray-700 text-sm font-semibold py-2 hover:bg-gray-50 transition-colors"
+              className="flex-1 flex items-center justify-center gap-1 rounded-lg border border-gray-300 text-gray-700 text-sm font-semibold py-2 hover:bg-gray-50 transition-colors cursor-pointer"
               onClick={(e) => e.stopPropagation()}
             >
               📞 문의하기
@@ -117,50 +117,51 @@ export default function KidsCafeCard({
               href={kidsCafe.detailUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex-1 flex items-center justify-center rounded-lg bg-blue-500 text-white text-sm font-semibold py-2 hover:bg-blue-600 transition-colors"
+              className="flex-1 flex items-center justify-center rounded-lg bg-blue-500 text-white text-sm font-semibold py-2 hover:bg-blue-600 transition-colors cursor-pointer"
               onClick={(e) => e.stopPropagation()}
             >
               🕐 이용안내
             </a>
           )}
+
+          {onShareMenuToggle && (
+            <div className="relative shrink-0">
+              <button
+                className="w-10 h-10 flex items-center justify-center rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition-colors cursor-pointer"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onShareMenuToggle();
+                }}
+                aria-label="공유하기"
+              >
+                {isCopied ? '✅' : '🔗'}
+              </button>
+
+              {isShareMenuOpen && (
+                <div className="absolute bottom-full right-0 mb-1 w-36 bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden z-10">
+                  <button
+                    className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2 cursor-pointer"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onShare?.('link');
+                    }}
+                  >
+                    🔗 링크 복사
+                  </button>
+                  <button
+                    className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2 border-t border-gray-100 cursor-pointer"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onShare?.('kakao');
+                    }}
+                  >
+                    💬 카카오톡
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
         </div>
-
-        {onShareMenuToggle && (
-          <div className="relative mt-1">
-            <button
-              className="w-full flex items-center justify-center gap-1 rounded-lg border border-gray-300 text-gray-700 text-sm font-semibold py-2 hover:bg-gray-50 transition-colors"
-              onClick={(e) => {
-                e.stopPropagation();
-                onShareMenuToggle();
-              }}
-            >
-              {isCopied ? '✅ 복사됨' : '🔗 공유하기 ▾'}
-            </button>
-
-            {isShareMenuOpen && (
-              <div className="absolute bottom-full left-0 mb-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden z-10">
-                <button
-                  className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onShare?.('link');
-                  }}
-                >
-                  🔗 링크 복사
-                </button>
-                <button
-                  className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2 border-t border-gray-100"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onShare?.('kakao');
-                  }}
-                >
-                  💬 카카오톡 공유
-                </button>
-              </div>
-            )}
-          </div>
-        )}
       </div>
     </article>
   );

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import dynamic from 'next/dynamic';
+import AgeFilterChips from '../../components/AgeFilterChips';
+import CafeListSection from '../../components/CafeListSection';
+import MobileTabBar from '../../components/MobileTabBar';
+import MapCafeCard from '../../components/MapCafeCard';
+const LocationBanner = dynamic(() => import('../../components/LocationBanner'), { ssr: false });
+import { useGeolocation } from '../lib/useGeolocation';
+import { useCafes } from '../lib/useCafes';
+import { useAgeFilter, useAgeChange } from '../lib/useAgeFilter';
+import { useCafeSelection } from '../lib/useCafeSelection';
+import { buildCafeListItems } from '../lib/cafeListUtils';
+import { isOpenToday } from '../lib/openStatus';
+import type { UserLocation } from '../lib/cafeListUtils';
+import KidsCafeCardSkeleton from '../../components/KidsCafeCard/Skeleton';
+
+const KakaoMap = dynamic(() => import('../../components/KakaoMap'), { ssr: false });
+const WelcomeModal = dynamic(() => import('../../components/WelcomeModal'), { ssr: false });
+
+type Tab = 'list' | 'map';
+
+export default function HomeClient() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const geolocation = useGeolocation();
+  const cafesState = useCafes();
+  const { selectedAges } = useAgeFilter();
+  const handleAgeChange = useAgeChange();
+  const { selectedCafeId, selectCafe, clearSelection } = useCafeSelection();
+  const [activeTab, setActiveTab] = useState<Tab>('list');
+
+  const selectedDistrict = searchParams.get('district');
+
+  function setDistrict(value: string | null) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set('district', value);
+    } else {
+      params.delete('district');
+    }
+    router.replace('?' + params.toString());
+  }
+
+  const userLocation = useMemo((): UserLocation | null => {
+    if (geolocation.status === 'granted' && geolocation.position !== null) {
+      return geolocation.position;
+    }
+    return null;
+  }, [geolocation.status, geolocation.position]);
+
+  const cafeListItems = useMemo(
+    () => buildCafeListItems(cafesState.cafes, selectedAges, userLocation, selectedDistrict),
+    [cafesState.cafes, selectedAges, userLocation, selectedDistrict]
+  );
+
+  const filteredCafesForMap = useMemo(
+    () =>
+      selectedDistrict
+        ? cafesState.cafes.filter((cafe) => cafe.address.includes(selectedDistrict))
+        : cafesState.cafes,
+    [cafesState.cafes, selectedDistrict]
+  );
+
+  const selectedCafeItem = useMemo(
+    () => cafeListItems.find((item) => item.cafe.id === selectedCafeId) ?? null,
+    [cafeListItems, selectedCafeId]
+  );
+
+  function handleRequestPermission() {
+    setDistrict(null);
+    geolocation.requestPermission();
+  }
+
+  function handleChangeDistrict() {
+    setDistrict(null);
+  }
+
+  function handleMarkerClick(id: string) {
+    selectCafe(id);
+  }
+
+  const listContent = (
+    <>
+      {cafesState.status === 'loading' && (
+        <div className="grid grid-cols-1 gap-4 pt-2 sm:grid-cols-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <KidsCafeCardSkeleton key={i} />
+          ))}
+        </div>
+      )}
+      {cafesState.status === 'error' && (
+        <div className="flex items-center justify-center py-20 text-red-500">
+          <p>{cafesState.error ?? '데이터를 불러오지 못했습니다.'}</p>
+        </div>
+      )}
+      {cafesState.status === 'success' && (
+        <CafeListSection
+          items={cafeListItems}
+          selectedCafeId={selectedCafeId}
+          onCardClick={selectCafe}
+        />
+      )}
+    </>
+  );
+
+  return (
+    <div className="flex flex-col h-screen overflow-hidden">
+      <WelcomeModal />
+      {/* 헤더 */}
+      <header className="bg-white border-b border-gray-200 px-4 py-3">
+        <h1 className="text-lg font-bold text-gray-900">서울형 키즈카페 목록</h1>
+      </header>
+
+      {/* 위치 배너 */}
+      <LocationBanner
+        status={geolocation.status}
+        selectedDistrict={selectedDistrict}
+        districts={cafesState.districts}
+        onRequestPermission={handleRequestPermission}
+        onSelectDistrict={setDistrict}
+        onChangeDistrict={handleChangeDistrict}
+      />
+
+      {/* 나이 필터 (sticky) */}
+      <AgeFilterChips selected={selectedAges} onChange={handleAgeChange} />
+
+      {/* 모바일 탭 바 */}
+      <MobileTabBar activeTab={activeTab} onChange={setActiveTab} />
+
+      {/* 본문 */}
+      <main className="flex flex-1 overflow-hidden">
+        {/* 데스크탑 전용 카드 리스트 */}
+        <section
+          className="hidden md:flex md:flex-col md:w-1/2 overflow-y-auto px-4 pb-4"
+          aria-label="카페 목록"
+        >
+          {listContent}
+        </section>
+
+        {/* 모바일 목록 탭 */}
+        <section
+          className={`flex flex-col flex-1 overflow-y-auto px-4 pb-4 md:hidden ${activeTab !== 'list' ? 'hidden' : ''}`}
+          aria-label="카페 목록"
+        >
+          {cafesState.status === 'loading' && (
+            <div className="grid grid-cols-1 gap-4 pt-2 sm:grid-cols-2">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <KidsCafeCardSkeleton key={i} />
+              ))}
+            </div>
+          )}
+          {cafesState.status === 'error' && (
+            <div className="flex items-center justify-center py-20 text-red-500">
+              <p>{cafesState.error ?? '데이터를 불러오지 못했습니다.'}</p>
+            </div>
+          )}
+          {cafesState.status === 'success' && (
+            <CafeListSection
+              items={cafeListItems}
+              selectedCafeId={selectedCafeId}
+              onCardClick={selectCafe}
+              scrollKey={activeTab}
+            />
+          )}
+        </section>
+
+        {/* 지도: 모바일 지도 탭 + 데스크탑 우측 */}
+        <section
+          className={`flex-1 relative md:flex px-4 pb-4 ${activeTab === 'map' ? 'flex' : 'hidden md:flex'}`}
+          aria-label="지도"
+        >
+          <KakaoMap
+            kidsCafes={filteredCafesForMap}
+            selectedKidsCafeId={selectedCafeId ?? undefined}
+            selectedAges={selectedAges}
+            onMarkerClick={handleMarkerClick}
+            onEmptyClick={clearSelection}
+            userPosition={userLocation}
+          />
+          {/* 모바일 마커 탭 미니 카드 */}
+          {selectedCafeItem && (
+            <MapCafeCard
+              cafe={selectedCafeItem.cafe}
+              distanceKm={selectedCafeItem.distanceKm ?? undefined}
+              isVisible={true}
+              cafeIsOpen={isOpenToday(selectedCafeItem.cafe.operatingHours)}
+              onClose={clearSelection}
+            />
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
+import Script from 'next/script';
 import './globals.css';
 import { SITE_URL } from '../lib/constants';
 
@@ -45,6 +46,12 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
+      <Script
+        id="kakao-sdk"
+        src="https://t1.kakaocdn.net/kakaojs/2.7.2/kakao.min.js"
+        crossOrigin="anonymous"
+        strategy="lazyOnload"
+      />
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -49,8 +49,7 @@ export default function RootLayout({
       <Script
         id="kakao-sdk"
         src="https://t1.kakaocdn.net/kakaojs/2.7.2/kakao.min.js"
-        crossOrigin="anonymous"
-        strategy="lazyOnload"
+        strategy="afterInteractive"
       />
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -48,7 +48,8 @@ export default function RootLayout({
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
       <Script
         id="kakao-sdk"
-        src="https://t1.kakaocdn.net/kakaojs/2.7.2/kakao.min.js"
+        src="https://t1.kakaocdn.net/kakao_js_sdk/2.8.1/kakao.min.js"
+        crossOrigin="anonymous"
         strategy="afterInteractive"
       />
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,197 +1,85 @@
-'use client';
+import { Suspense } from 'react';
+import type { Metadata } from 'next';
+import HomeClient from './HomeClient';
+import { getEnrichedCafes } from '../lib/cafe-data';
+import { SITE_URL } from '../lib/constants';
 
-import { useState, useMemo } from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
-import dynamic from 'next/dynamic';
-import AgeFilterChips from '../../components/AgeFilterChips';
-import CafeListSection from '../../components/CafeListSection';
-import MobileTabBar from '../../components/MobileTabBar';
-import MapCafeCard from '../../components/MapCafeCard';
-const LocationBanner = dynamic(() => import('../../components/LocationBanner'), { ssr: false });
-import { useGeolocation } from '../lib/useGeolocation';
-import { useCafes } from '../lib/useCafes';
-import { useAgeFilter, useAgeChange } from '../lib/useAgeFilter';
-import { useCafeSelection } from '../lib/useCafeSelection';
-import { buildCafeListItems } from '../lib/cafeListUtils';
-import { isOpenToday } from '../lib/openStatus';
-import type { UserLocation } from '../lib/cafeListUtils';
-import KidsCafeCardSkeleton from '../../components/KidsCafeCard/Skeleton';
+const SITE_TITLE = '이모표 서울형 키즈카페';
+const SITE_DESCRIPTION = '서울 공공 키즈카페 한눈에 찾기 — 나이·지역 필터 + 카카오맵';
 
-const KakaoMap = dynamic(() => import('../../components/KakaoMap'), { ssr: false });
-const WelcomeModal = dynamic(() => import('../../components/WelcomeModal'), { ssr: false });
+type PageProps = {
+  searchParams: Promise<{ cafeId?: string }>;
+};
 
-type Tab = 'list' | 'map';
+function defaultMetadata(): Metadata {
+  return {
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    openGraph: {
+      title: SITE_TITLE,
+      description: SITE_DESCRIPTION,
+      url: SITE_URL,
+      siteName: SITE_TITLE,
+      locale: 'ko_KR',
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: SITE_TITLE,
+      description: SITE_DESCRIPTION,
+    },
+  };
+}
+
+export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
+  const { cafeId } = await searchParams;
+
+  if (!cafeId) return defaultMetadata();
+
+  const seoulApiKey = process.env.SEOUL_API_KEY;
+  const kakaoRestApiKey = process.env.KAKAO_REST_API_KEY;
+
+  if (!seoulApiKey || !kakaoRestApiKey) return defaultMetadata();
+
+  const cafes = await getEnrichedCafes(seoulApiKey, kakaoRestApiKey);
+  const cafe = cafes.find((c) => c.id === cafeId);
+
+  if (!cafe) return defaultMetadata();
+
+  const title = `${cafe.name} | ${SITE_TITLE}`;
+  const description = [
+    `📍 주소: ${cafe.address}`,
+    `👶 이용 나이: ${cafe.ageRange.minAge} ~ ${cafe.ageRange.maxAge}세`,
+    cafe.operatingHours ? `📅 운영 요일: ${cafe.operatingHours}` : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: `${SITE_URL}?cafeId=${cafeId}`,
+      siteName: SITE_TITLE,
+      locale: 'ko_KR',
+      type: 'website',
+      ...(cafe.imageUrl ? { images: [{ url: cafe.imageUrl }] } : {}),
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      ...(cafe.imageUrl ? { images: [cafe.imageUrl] } : {}),
+    },
+  };
+}
 
 export default function Home() {
-  const searchParams = useSearchParams();
-  const router = useRouter();
-  const geolocation = useGeolocation();
-  const cafesState = useCafes();
-  const { selectedAges } = useAgeFilter();
-  const handleAgeChange = useAgeChange();
-  const { selectedCafeId, selectCafe, clearSelection } = useCafeSelection();
-  const [activeTab, setActiveTab] = useState<Tab>('list');
-
-  const selectedDistrict = searchParams.get('district');
-
-  function setDistrict(value: string | null) {
-    const params = new URLSearchParams(searchParams.toString());
-    if (value) {
-      params.set('district', value);
-    } else {
-      params.delete('district');
-    }
-    router.replace('?' + params.toString());
-  }
-
-  const userLocation = useMemo((): UserLocation | null => {
-    if (geolocation.status === 'granted' && geolocation.position !== null) {
-      return geolocation.position;
-    }
-    return null;
-  }, [geolocation.status, geolocation.position]);
-
-  const cafeListItems = useMemo(
-    () => buildCafeListItems(cafesState.cafes, selectedAges, userLocation, selectedDistrict),
-    [cafesState.cafes, selectedAges, userLocation, selectedDistrict]
-  );
-
-  const filteredCafesForMap = useMemo(
-    () =>
-      selectedDistrict
-        ? cafesState.cafes.filter((cafe) => cafe.address.includes(selectedDistrict))
-        : cafesState.cafes,
-    [cafesState.cafes, selectedDistrict]
-  );
-
-  const selectedCafeItem = useMemo(
-    () => cafeListItems.find((item) => item.cafe.id === selectedCafeId) ?? null,
-    [cafeListItems, selectedCafeId]
-  );
-
-  function handleRequestPermission() {
-    setDistrict(null);
-    geolocation.requestPermission();
-  }
-
-  function handleChangeDistrict() {
-    setDistrict(null);
-  }
-
-  function handleMarkerClick(id: string) {
-    selectCafe(id);
-  }
-
-  const listContent = (
-    <>
-      {cafesState.status === 'loading' && (
-        <div className="grid grid-cols-1 gap-4 pt-2 sm:grid-cols-2">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <KidsCafeCardSkeleton key={i} />
-          ))}
-        </div>
-      )}
-      {cafesState.status === 'error' && (
-        <div className="flex items-center justify-center py-20 text-red-500">
-          <p>{cafesState.error ?? '데이터를 불러오지 못했습니다.'}</p>
-        </div>
-      )}
-      {cafesState.status === 'success' && (
-        <CafeListSection
-          items={cafeListItems}
-          selectedCafeId={selectedCafeId}
-          onCardClick={selectCafe}
-        />
-      )}
-    </>
-  );
-
   return (
-    <div className="flex flex-col h-screen overflow-hidden">
-      <WelcomeModal />
-      {/* 헤더 */}
-      <header className="bg-white border-b border-gray-200 px-4 py-3">
-        <h1 className="text-lg font-bold text-gray-900">서울형 키즈카페 목록</h1>
-      </header>
-
-      {/* 위치 배너 */}
-      <LocationBanner
-        status={geolocation.status}
-        selectedDistrict={selectedDistrict}
-        districts={cafesState.districts}
-        onRequestPermission={handleRequestPermission}
-        onSelectDistrict={setDistrict}
-        onChangeDistrict={handleChangeDistrict}
-      />
-
-      {/* 나이 필터 (sticky) */}
-      <AgeFilterChips selected={selectedAges} onChange={handleAgeChange} />
-
-      {/* 모바일 탭 바 */}
-      <MobileTabBar activeTab={activeTab} onChange={setActiveTab} />
-
-      {/* 본문 */}
-      <main className="flex flex-1 overflow-hidden">
-        {/* 데스크탑 전용 카드 리스트 */}
-        <section
-          className="hidden md:flex md:flex-col md:w-1/2 overflow-y-auto px-4 pb-4"
-          aria-label="카페 목록"
-        >
-          {listContent}
-        </section>
-
-        {/* 모바일 목록 탭 */}
-        <section
-          className={`flex flex-col flex-1 overflow-y-auto px-4 pb-4 md:hidden ${activeTab !== 'list' ? 'hidden' : ''}`}
-          aria-label="카페 목록"
-        >
-          {cafesState.status === 'loading' && (
-            <div className="grid grid-cols-1 gap-4 pt-2 sm:grid-cols-2">
-              {Array.from({ length: 6 }).map((_, i) => (
-                <KidsCafeCardSkeleton key={i} />
-              ))}
-            </div>
-          )}
-          {cafesState.status === 'error' && (
-            <div className="flex items-center justify-center py-20 text-red-500">
-              <p>{cafesState.error ?? '데이터를 불러오지 못했습니다.'}</p>
-            </div>
-          )}
-          {cafesState.status === 'success' && (
-            <CafeListSection
-              items={cafeListItems}
-              selectedCafeId={selectedCafeId}
-              onCardClick={selectCafe}
-              scrollKey={activeTab}
-            />
-          )}
-        </section>
-
-        {/* 지도: 모바일 지도 탭 + 데스크탑 우측 */}
-        <section
-          className={`flex-1 relative md:flex px-4 pb-4 ${activeTab === 'map' ? 'flex' : 'hidden md:flex'}`}
-          aria-label="지도"
-        >
-          <KakaoMap
-            kidsCafes={filteredCafesForMap}
-            selectedKidsCafeId={selectedCafeId ?? undefined}
-            selectedAges={selectedAges}
-            onMarkerClick={handleMarkerClick}
-            onEmptyClick={clearSelection}
-            userPosition={userLocation}
-          />
-          {/* 모바일 마커 탭 미니 카드 */}
-          {selectedCafeItem && (
-            <MapCafeCard
-              cafe={selectedCafeItem.cafe}
-              distanceKm={selectedCafeItem.distanceKm ?? undefined}
-              isVisible={true}
-              cafeIsOpen={isOpenToday(selectedCafeItem.cafe.operatingHours)}
-              onClose={clearSelection}
-            />
-          )}
-        </section>
-      </main>
-    </div>
+    <Suspense>
+      <HomeClient />
+    </Suspense>
   );
 }

--- a/src/lib/kidsCafeCard.ts
+++ b/src/lib/kidsCafeCard.ts
@@ -7,6 +7,7 @@ export interface KidsCafeCardProps {
   isOpen: boolean;
   onClick?: () => void;
   isSelected?: boolean;
+  onShareMenuToggle?: () => void;
   onShare?: (action: 'link' | 'kakao') => void;
   isShareMenuOpen?: boolean;
   isCopied?: boolean;

--- a/src/lib/kidsCafeCard.ts
+++ b/src/lib/kidsCafeCard.ts
@@ -7,7 +7,9 @@ export interface KidsCafeCardProps {
   isOpen: boolean;
   onClick?: () => void;
   isSelected?: boolean;
-  priority?: boolean;
+  onShare?: (action: 'link' | 'kakao') => void;
+  isShareMenuOpen?: boolean;
+  isCopied?: boolean;
 }
 
 export function formatAgeRange(ageRange: KidsCafe['ageRange']): string {

--- a/src/lib/useShareMenu.ts
+++ b/src/lib/useShareMenu.ts
@@ -1,0 +1,77 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import type { KidsCafe } from '../../types/index';
+
+export type UseShareMenuReturn = {
+  openMenuId: string | null;
+  toggleMenu: (id: string) => void;
+  closeMenu: () => void;
+  copiedId: string | null;
+  copyLink: (cafeId: string) => Promise<void>;
+  shareKakao: (cafeId: string, cafe: KidsCafe) => void;
+};
+
+export function useShareMenu(): UseShareMenuReturn {
+  const searchParams = useSearchParams();
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const toggleMenu = useCallback((id: string) => {
+    setOpenMenuId((prev) => (prev === id ? null : id));
+  }, []);
+
+  const closeMenu = useCallback(() => {
+    setOpenMenuId(null);
+  }, []);
+
+  const buildShareUrl = useCallback(
+    (cafeId: string): string => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('cafeId', cafeId);
+      return `${window.location.origin}?${params.toString()}`;
+    },
+    [searchParams],
+  );
+
+  const copyLink = useCallback(
+    async (cafeId: string): Promise<void> => {
+      const url = buildShareUrl(cafeId);
+      await navigator.clipboard.writeText(url);
+      setCopiedId(cafeId);
+      setOpenMenuId(null);
+      setTimeout(() => setCopiedId((prev) => (prev === cafeId ? null : prev)), 2000);
+    },
+    [buildShareUrl],
+  );
+
+  const shareKakao = useCallback(
+    (cafeId: string, cafe: KidsCafe): void => {
+      if (!window.Kakao) return;
+      if (!window.Kakao.isInitialized()) {
+        window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY ?? '');
+      }
+      const shareUrl = buildShareUrl(cafeId);
+      window.Kakao.Share.sendDefault({
+        objectType: 'feed',
+        content: {
+          title: cafe.name,
+          description: cafe.address,
+          imageUrl: cafe.imageUrl || undefined,
+          link: { mobileWebUrl: shareUrl, webUrl: shareUrl },
+        },
+        buttons: [
+          {
+            title: '지도에서 보기',
+            link: { mobileWebUrl: shareUrl, webUrl: shareUrl },
+          },
+        ],
+      });
+      setOpenMenuId(null);
+    },
+    [buildShareUrl],
+  );
+
+  return { openMenuId, toggleMenu, closeMenu, copiedId, copyLink, shareKakao };
+}

--- a/types/kakao-map.ts
+++ b/types/kakao-map.ts
@@ -114,8 +114,40 @@ export interface KakaoMarker {
   getRange: () => number;
 }
 
+export interface KakaoShareLinkObject {
+  mobileWebUrl: string;
+  webUrl: string;
+}
+
+export interface KakaoShareContent {
+  title: string;
+  description?: string;
+  imageUrl?: string;
+  link: KakaoShareLinkObject;
+}
+
+export interface KakaoShareButton {
+  title: string;
+  link: KakaoShareLinkObject;
+}
+
+export interface KakaoShareFeedOptions {
+  objectType: 'feed';
+  content: KakaoShareContent;
+  buttons?: KakaoShareButton[];
+}
+
+export interface KakaoShareNamespace {
+  sendDefault(options: KakaoShareFeedOptions): void;
+}
+
 declare global {
   interface Window {
+    Kakao: {
+      init(key: string): void;
+      isInitialized(): boolean;
+      Share: KakaoShareNamespace;
+    };
     kakao: {
       maps: {
         load: (callback: () => void) => void;


### PR DESCRIPTION
## 변경 내용

- \`page.tsx\`를 Server Component로 전환 후 \`generateMetadata\` 추가
- \`cafeId\` 쿼리 파라미터 기반으로 카페별 OG 메타태그 동적 생성
- 클라이언트 로직을 \`HomeClient.tsx\`로 분리

## 동작 방식

카카오톡에서 \`?cafeId=xxx\` URL 공유 시 크롤러가 서버 렌더링된 HTML을 파싱 → 해당 카페의 OG 태그 노출

**카페 선택 시**
- \`og:title\`: \`카페이름 | 이모표 서울형 키즈카페\`
- \`og:description\`:
  ```
  📍 주소: 서울특별시 강남구 ...
  👶 이용 나이: 0 ~ 6세
  📅 운영 요일: 월 ~ 토
  ```
- \`og:image\`: 카페 대표 이미지 (없으면 사이트 기본 OG 이미지 fallback)

**카페 미선택 / 데이터 없음**: 사이트 기본 OG로 fallback

## 테스트 체크리스트

- [x] `/?cafeId={id}` 접속 후 DevTools `<head>`에서 카페별 OG 태그 확인
- [x] `cafeId` 없는 URL에서 기본 OG 노출 확인
- [x] 존재하지 않는 `cafeId`에서 기본 OG fallback 확인
- [ ] 배포 후 카카오 공유 디버거로 카드 미리보기 확인