### PR TITLE
fix: 카카오톡 공유를 피드에서 링크(sendScrap) 방식으로 변경

### DIFF
--- a/components/CafeListSection.tsx
+++ b/components/CafeListSection.tsx
@@ -52,7 +52,7 @@ export default function CafeListSection({
             onShare={(action) =>
               action === 'link'
                 ? copyLink(cafe.id)
-                : shareKakao(cafe.id, cafe)
+                : shareKakao(cafe.id)
             }
             isShareMenuOpen={openMenuId === cafe.id}
             isCopied={copiedId === cafe.id}

--- a/src/lib/useShareMenu.ts
+++ b/src/lib/useShareMenu.ts
@@ -2,7 +2,6 @@
 
 import { useCallback, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import type { KidsCafe } from '../../types/index';
 
 export type UseShareMenuReturn = {
   openMenuId: string | null;
@@ -10,7 +9,7 @@ export type UseShareMenuReturn = {
   closeMenu: () => void;
   copiedId: string | null;
   copyLink: (cafeId: string) => Promise<void>;
-  shareKakao: (cafeId: string, cafe: KidsCafe) => void;
+  shareKakao: (cafeId: string) => void;
 };
 
 export function useShareMenu(): UseShareMenuReturn {
@@ -47,27 +46,13 @@ export function useShareMenu(): UseShareMenuReturn {
   );
 
   const shareKakao = useCallback(
-    (cafeId: string, cafe: KidsCafe): void => {
+    (cafeId: string): void => {
       if (!window.Kakao) return;
       if (!window.Kakao.isInitialized()) {
         window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY ?? '');
       }
       const shareUrl = buildShareUrl(cafeId);
-      window.Kakao.Share.sendDefault({
-        objectType: 'feed',
-        content: {
-          title: cafe.name,
-          description: cafe.address,
-          imageUrl: cafe.imageUrl || undefined,
-          link: { mobileWebUrl: shareUrl, webUrl: shareUrl },
-        },
-        buttons: [
-          {
-            title: '지도에서 보기',
-            link: { mobileWebUrl: shareUrl, webUrl: shareUrl },
-          },
-        ],
-      });
+      window.Kakao.Share.sendScrap({ requestUrl: shareUrl });
       setOpenMenuId(null);
     },
     [buildShareUrl],

--- a/types/kakao-map.ts
+++ b/types/kakao-map.ts
@@ -137,8 +137,15 @@ export interface KakaoShareFeedOptions {
   buttons?: KakaoShareButton[];
 }
 
+export interface KakaoShareScrapOptions {
+  requestUrl: string;
+  templateId?: number;
+  templateArgs?: Record<string, string>;
+}
+
 export interface KakaoShareNamespace {
   sendDefault(options: KakaoShareFeedOptions): void;
+  sendScrap(options: KakaoShareScrapOptions): void;
 }
 
 declare global {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "fix/kakao-share-scrap": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `sendDefault` (피드 카드) → `sendScrap` (URL 기반 링크 미리보기)으로 전환
- 카카오가 OG 메타태그를 직접 스크랩해 공유 미리보기 자동 생성
- `shareKakao` 시그니처에서 불필요한 `cafe` 파라미터 제거

## Test plan

- [ ] Vercel preview URL로 배포 확인 (`fix/kakao-share-scrap` 브랜치)
- [ ] 카드의 카카오톡 공유 버튼 클릭 → 카카오톡 링크 미리보기 형태로 공유 시트 표시 확인
- [ ] 공유 링크 클릭 시 해당 카페가 선택된 상태로 페이지 이동 확인